### PR TITLE
Compatibility with Thunderbird 128

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,7 @@
     "browser_specific_settings": {
         "gecko": {
             "id": "tagger@xot.nl",
-            "strict_min_version": "128.0"
+            "strict_min_version": "122.0"
         }
     },
     "browser_action": {

--- a/manifest.json
+++ b/manifest.json
@@ -2,12 +2,12 @@
     "manifest_version": 2,
     "name": "Tagger",
     "description": "Tagging messages by autocompletion",
-    "version": "1.2",
+    "version": "1.3",
     "author": "Jaap-Henk Hoepman",
     "browser_specific_settings": {
         "gecko": {
             "id": "tagger@xot.nl",
-            "strict_min_version": "102.0"
+            "strict_min_version": "128.0"
         }
     },
     "browser_action": {
@@ -28,7 +28,8 @@
     },
     "permissions": [
 	"accountsRead",
-        "messagesRead",
+	"messagesRead",
+	"messagesUpdate",
 	"messagesTags",
 	"storage"
     ],


### PR DESCRIPTION
Thunderbird 128 introduced a rare backward incompatibility in its WebExtension API: The method `messages.update()` is now protected by the `messagesUpdate` permission.